### PR TITLE
Simplify documentation workflow with sphinx-notes/pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,25 +9,14 @@ permissions:
   contents: write
 
 jobs:
-  generate-docs:
+  pages:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v5
+      - id: deployment
+        uses: sphinx-notes/pages@v3
         with:
-          python-version: "3.11"
-          enablle-cache: true
-          cache-dependency-glob: uv.lock
-      - name: Install dependencies
-        run: uv sync --locked --all-extras
-      - name: Generate documentation
-        run: uv run sphinx-build docs _build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        if: ${{github.ref == 'refs/heads/main' && github.event_name == 'push'}}
+          publish: false
+      - uses: peaceiris/actions-gh-pages@v3
         with:
-          publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_build
-          force_orphan: true
+          publish_dir: ${{ steps.deployment.outputs.artifact }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,8 @@ jobs:
         uses: sphinx-notes/pages@v3
         with:
           publish: false
-      - uses: peaceiris/actions-gh-pages@v3
+      - if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ steps.deployment.outputs.artifact }}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,4 @@
 
-hidrowebsdk/docs/index.rst
 Bem-vindo à documentação do HidroWebSDK!
 =========================================
 


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to simplify and modernize the process by switching to a dedicated Sphinx Pages action, and makes a minor formatting fix in the documentation index file.

**Documentation workflow improvements:**

* Replaces the manual documentation build and deployment steps in `.github/workflows/documentation.yml` with the `sphinx-notes/pages@v3` action for building Sphinx docs, and updates the deployment to use the output artifact from this action.

**Documentation formatting:**

* Removes an extraneous line from the top of `docs/index.rst` for cleaner formatting.