### PR TITLE
Add estacoes_hidrosat method and tests for Hidrosat inventory

### DIFF
--- a/hidrowebsdk/client.py
+++ b/hidrowebsdk/client.py
@@ -388,7 +388,7 @@ class Client:
 
         Parâmetros
         ----------
-        codigo : int, opcional
+        codigo : str, opcional
             Código da estação para filtrar resultados.
         last_update_start : datetime, opcional
             Data de início para filtro de última atualização (aaaa-MM-dd).

--- a/hidrowebsdk/client.py
+++ b/hidrowebsdk/client.py
@@ -380,7 +380,7 @@ class Client:
 
     async def estacoes_hidrosat(
         self,
-        codigo: int | None = None,
+        codigo: str = "",
         last_update_start: datetime | None = None,
         last_update_end: datetime | None = None,
     ) -> pd.DataFrame:
@@ -402,7 +402,7 @@ class Client:
         """
         endpoint_suffix = "HidrosatInventarioEstacoes/v1"
         params = {}
-        if codigo is not None:
+        if codigo:
             params["Código da Estação"] = codigo
         if last_update_start is not None:
             params["Data Atualização Inicial (yyyy-MM-dd)"] = (

--- a/hidrowebsdk/client.py
+++ b/hidrowebsdk/client.py
@@ -378,6 +378,42 @@ class Client:
             params["Código da Bacia"] = basin_code
         return await self._df_from_api(endpoint_suffix, params)
 
+    async def estacoes_hidrosat(
+        self,
+        codigo: int | None = None,
+        last_update_start: datetime | None = None,
+        last_update_end: datetime | None = None,
+    ) -> pd.DataFrame:
+        """Busca inventário de estações de monitoramento.
+
+        Parâmetros
+        ----------
+        codigo : int, opcional
+            Código da estação para filtrar resultados.
+        last_update_start : datetime, opcional
+            Data de início para filtro de última atualização (aaaa-MM-dd).
+        last_update_end : datetime, opcional
+            Data de fim para filtro de última atualização (aaaa-MM-dd).
+
+        Retorna
+        -------
+        pd.DataFrame
+            DataFrame contendo inventário da estação.
+        """
+        endpoint_suffix = "HidrosatInventarioEstacoes/v1"
+        params = {}
+        if codigo is not None:
+            params["Código da Estação"] = codigo
+        if last_update_start is not None:
+            params["Data Atualização Inicial (yyyy-MM-dd)"] = (
+                last_update_start.strftime("%Y-%m-%d")
+            )
+        if last_update_end is not None:
+            params["Data Atualização Final (yyyy-MM-dd)"] = last_update_end.strftime(
+                "%Y-%m-%d"
+            )
+        return await self._df_from_api(endpoint_suffix, params)
+
     async def _telemetry_method(
         self,
         endpoint_suffix: str,
@@ -578,6 +614,12 @@ methods_to_add = [
         "method_name": "serie_curva_descarga",
         "method_description": "Busca série histórica de dados de curva de descarga para uma estação específica.",
         "return_description": "DataFrame contendo a série histórica de dados de curva de descarga.",
+    },
+    {
+        "endpoint_suffix": "HidrosatSerieDados/v1",
+        "method_name": "serie_hidrosat",
+        "method_description": "Busca série histórica de dados do Hidrosat para uma estação virtual específica.",
+        "return_description": "DataFrame contendo a série histórica de dados do Hidrosat.",
     },
 ]
 for method in methods_to_add:

--- a/tests/test_estacoes_hidrosat.py
+++ b/tests/test_estacoes_hidrosat.py
@@ -1,0 +1,44 @@
+import pytest_asyncio
+import pytest
+
+codigo = "3122S05150W0"
+required_columns = [
+    "Corpo_Hidrico",
+    "Estacao_Nome",
+    "Estacao_Status",
+    "Latitude",
+    "Longitude",
+    "Pais",
+    "UF",
+    "codigoestacao",
+]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def estacao_hidrosat_codigo_filter(client):
+    """Fixture to fetch estacao by codigo."""
+    return await client.estacoes_hidrosat(codigo=codigo)
+
+
+@pytest.mark.asyncio
+async def test_estacao_hidrosat_codigo_filter_not_empty(estacao_hidrosat_codigo_filter):
+    """Test if filtering by codigo returns the correct estacao."""
+    assert not estacao_hidrosat_codigo_filter.empty, (
+        f"No estacao found for codigo {codigo}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_estacao_hidrosat_codigo_filter_correct(estacao_hidrosat_codigo_filter):
+    assert estacao_hidrosat_codigo_filter.iloc[0]["codigoestacao"] == codigo, (
+        f"Returned estacoes do not match codigo {codigo}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_estacao_hidrosat_required_columns(estacao_hidrosat_codigo_filter):
+    """Test if the fetched estacao data contains the required fields."""
+    for column in required_columns:
+        assert column in estacao_hidrosat_codigo_filter.columns, (
+            f"Missing column: {column}"
+        )


### PR DESCRIPTION
This pull request adds support for retrieving and testing Hidrosat station inventory and time series data in the SDK. The main changes include a new async method to fetch Hidrosat station inventories, dynamic addition of a new time series method, and comprehensive tests for the new inventory endpoint.

**New Hidrosat inventory endpoint support:**

* Added `estacoes_hidrosat` async method to `hidrowebsdk/client.py` for fetching Hidrosat station inventory with optional filters for station code and last update date range.

**Hidrosat time series data support:**

* Dynamically registered a new `serie_hidrosat` method for retrieving Hidrosat time series data using the generic method registration pattern.

**Testing improvements:**

* Added `tests/test_estacoes_hidrosat.py` to verify the correctness of the new `estacoes_hidrosat` endpoint, including tests for filtering by station code and checking required columns in the results.