### PR TITLE
Add async methods for estados, municipios, sub_bacias, and rios

### DIFF
--- a/hidrowebsdk/client.py
+++ b/hidrowebsdk/client.py
@@ -263,6 +263,63 @@ class Client:
             )
         return api_response.items_as_dataframe()
 
+    async def estados(
+        self,
+        codigo: int | None = None,
+        last_update_start: datetime | None = None,
+        last_update_end: datetime | None = None,
+    ) -> pd.DataFrame:
+        """Busca informações sobre estados (Unidades Federativas).
+
+        Parâmetros
+        ----------
+        codigo : int, opcional
+            Código do estado para filtrar resultados.
+        last_update_start : datetime, opcional
+            Data de início para filtro de última atualização.
+        last_update_end : datetime, opcional
+            Data de fim para filtro de última atualização.
+
+        Retorna
+        -------
+        pd.DataFrame
+            DataFrame contendo informações dos estados.
+        """
+        endpoint_suffix = "HidroUF/v1"
+        return await self._df_from_api(endpoint_suffix)
+
+    async def municipios(
+        self,
+        codigo: int | None = None,
+        last_update_start: datetime | None = None,
+        last_update_end: datetime | None = None,
+    ) -> pd.DataFrame:
+        """Busca informações sobre municípios.
+
+        Parâmetros
+        ----------
+        codigo : int, opcional
+            Código do município para filtrar resultados.
+        last_update_start : datetime, opcional
+            Data de início para filtro de última atualização.
+        last_update_end : datetime, opcional
+            Data de fim para filtro de última atualização.
+
+        Retorna
+        -------
+        pd.DataFrame ou None
+            DataFrame contendo informações do município
+        """
+        endpoint_suffix = "HidroMunicipio/v1"
+        params = {}
+        if codigo is not None:
+            params["Código do Município"] = codigo
+        if last_update_start is not None:
+            params["Data Atualização Inicial"] = last_update_start.strftime("%Y-%m-%d")
+        if last_update_end is not None:
+            params["Data Atualização Final"] = last_update_end.strftime("%Y-%m-%d")
+        return await self._df_from_api(endpoint_suffix, params)
+
     async def bacias(
         self,
         codigo: int | None = None,
@@ -289,6 +346,70 @@ class Client:
         params = {}
         if codigo is not None:
             params["Código da Bacia"] = codigo
+        if last_update_start is not None:
+            params["Data Atualização Inicial"] = last_update_start.strftime("%Y-%m-%d")
+        if last_update_end is not None:
+            params["Data Atualização Final"] = last_update_end.strftime("%Y-%m-%d")
+        return await self._df_from_api(endpoint_suffix, params)
+
+    async def sub_bacias(
+        self,
+        codigo: int | None = None,
+        last_update_start: datetime | None = None,
+        last_update_end: datetime | None = None,
+    ) -> pd.DataFrame:
+        """Busca informações sobre sub-bacias hidrológicas.
+
+        Parâmetros
+        ----------
+        codigo : int, opcional
+            Código da sub-bacia para filtrar resultados.
+        last_update_start : datetime, opcional
+            Data de início para filtro de última atualização.
+        last_update_end : datetime, opcional
+            Data de fim para filtro de última atualização.
+
+        Retorna
+        -------
+        pd.DataFrame ou None
+            DataFrame contendo informações da sub-bacia
+        """
+        endpoint_suffix = "HidroSubBacia/v1"
+        params = {}
+        if codigo is not None:
+            params["Código da Sub-Bacia"] = codigo
+        if last_update_start is not None:
+            params["Data Atualização Inicial"] = last_update_start.strftime("%Y-%m-%d")
+        if last_update_end is not None:
+            params["Data Atualização Final"] = last_update_end.strftime("%Y-%m-%d")
+        return await self._df_from_api(endpoint_suffix, params)
+
+    async def rios(
+        self,
+        codigo: int | None = None,
+        last_update_start: datetime | None = None,
+        last_update_end: datetime | None = None,
+    ) -> pd.DataFrame:
+        """Busca informações sobre rios.
+
+        Parâmetros
+        ----------
+        codigo : int, opcional
+            Código do rio para filtrar resultados.
+        last_update_start : datetime, opcional
+            Data de início para filtro de última atualização.
+        last_update_end : datetime, opcional
+            Data de fim para filtro de última atualização.
+
+        Retorna
+        -------
+        pd.DataFrame ou None
+            DataFrame contendo informações do rio
+        """
+        endpoint_suffix = "HidroRio/v1"
+        params = {}
+        if codigo is not None:
+            params["Código do Rio"] = codigo
         if last_update_start is not None:
             params["Data Atualização Inicial"] = last_update_start.strftime("%Y-%m-%d")
         if last_update_end is not None:
@@ -724,13 +845,7 @@ if __name__ == "__main__":
     async def main():
         async with Client() as client:
             await client.authenticate()
-            print(client.token)
-            stations = [30659600, 13445000]
-            df = await client.serie_telemetrica_detalhada_multiplas_estacoes(
-                codigos=stations,
-                end_datetime=datetime(2025, 8, 28),
-                range_filter=RangeFilter.ONE_HOUR,
-            )
+            df = await client.sub_bacias()
             print(df)
             print(df.columns.tolist())
 

--- a/hidrowebsdk/client.py
+++ b/hidrowebsdk/client.py
@@ -844,16 +844,3 @@ for method in methods_to_add:
             method["return_description"],
         ),
     )
-
-
-if __name__ == "__main__":
-    import asyncio
-
-    async def main():
-        async with Client() as client:
-            await client.authenticate()
-            df = await client.sub_bacias()
-            print(df)
-            print(df.columns.tolist())
-
-    asyncio.run(main())

--- a/hidrowebsdk/client.py
+++ b/hidrowebsdk/client.py
@@ -286,7 +286,14 @@ class Client:
             DataFrame contendo informações dos estados.
         """
         endpoint_suffix = "HidroUF/v1"
-        return await self._df_from_api(endpoint_suffix)
+        params = {}
+        if codigo is not None:
+            params["Código da UF"] = codigo
+        if last_update_start is not None:
+            params["Data Atualização Inicial"] = last_update_start.strftime("%Y-%m-%d")
+        if last_update_end is not None:
+            params["Data Atualização Final"] = last_update_end.strftime("%Y-%m-%d")
+        return await self._df_from_api(endpoint_suffix, params)
 
     async def municipios(
         self,

--- a/tests/test_estados.py
+++ b/tests/test_estados.py
@@ -1,7 +1,7 @@
 import pytest_asyncio
 import pytest
 
-codigo = "1"
+codigo = "2"
 required_columns = [
     "Data_Ultima_Alteracao",
     "Estado_Codigo_IBGE",

--- a/tests/test_estados.py
+++ b/tests/test_estados.py
@@ -33,7 +33,7 @@ async def test_estados_not_empty(estados_result):
 
 @pytest_asyncio.fixture(scope="module")
 async def estados_codigo_filter(client):
-    """Fixture to estados by codigo."""
+    """Fixture to fetch estados by codigo."""
     return await client.estados(codigo=codigo)
 
 

--- a/tests/test_estados.py
+++ b/tests/test_estados.py
@@ -1,0 +1,50 @@
+import pytest_asyncio
+import pytest
+
+codigo = "1"
+required_columns = [
+    "Data_Ultima_Alteracao",
+    "Estado_Codigo_IBGE",
+    "Estado_Nome",
+    "Estado_Sigla",
+    "codigouf",
+]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def estados_result(client):
+    """Fixture to fetch estados data once for all tests in this file."""
+    return await client.estados()
+
+
+@pytest.mark.asyncio
+async def test_estados_columns(estados_result):
+    """Test if estados result contains the required columns."""
+    assert all(col in estados_result.columns for col in required_columns), (
+        f"Missing columns in Estado result: {set(required_columns) - set(estados_result.columns)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_estados_not_empty(estados_result):
+    """Test if estados result is not empty."""
+    assert not estados_result.empty, "Estados result is empty"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def estados_codigo_filter(client):
+    """Fixture to estados by codigo."""
+    return await client.estados(codigo=codigo)
+
+
+@pytest.mark.asyncio
+async def test_estados_codigo_filter_not_empty(estados_codigo_filter):
+    """Test if filtering by codigo returns the correct estados."""
+    assert not estados_codigo_filter.empty, f"No estados found for codigo {codigo}"
+
+
+@pytest.mark.asyncio
+async def test_estados_codigo_filter_correct(estados_codigo_filter):
+    assert estados_codigo_filter.iloc[0]["codigouf"] == codigo, (
+        f"Returned estado do not match codigo {codigo}"
+    )

--- a/tests/test_municipios.py
+++ b/tests/test_municipios.py
@@ -1,0 +1,52 @@
+import pytest_asyncio
+import pytest
+
+codigo = "1000500"
+required_columns = [
+    "Data_Ultima_Alteracao",
+    "Estado_Codigo",
+    "Municipio_Codigo_IBGE",
+    "Municipio_Nome",
+    "codigomunicipio",
+]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def municipios_result(client):
+    """Fixture to fetch municipios data once for all tests in this file."""
+    return await client.municipios()
+
+
+@pytest.mark.asyncio
+async def test_estados_columns(municipios_result):
+    """Test if municipios result contains the required columns."""
+    assert all(col in municipios_result.columns for col in required_columns), (
+        f"Missing columns in Estado result: {set(required_columns) - set(municipios_result.columns)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_estados_not_empty(municipios_result):
+    """Test if municipios result is not empty."""
+    assert not municipios_result.empty, "Estados result is empty"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def municipios_codigo_filter(client):
+    """Fixture to fetch municipios by codigo."""
+    return await client.municipios(codigo=codigo)
+
+
+@pytest.mark.asyncio
+async def test_municipio_codigo_filter_not_empty(municipios_codigo_filter):
+    """Test if filtering by codigo returns the correct municipios."""
+    assert not municipios_codigo_filter.empty, (
+        f"No municipios found for codigo {codigo}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_municipios_codigo_filter_correct(municipios_codigo_filter):
+    assert municipios_codigo_filter.iloc[0]["codigomunicipio"] == codigo, (
+        f"Returned estado do not match codigo {codigo}"
+    )

--- a/tests/test_rios.py
+++ b/tests/test_rios.py
@@ -1,0 +1,51 @@
+import pytest_asyncio
+import pytest
+
+codigo = "10000050"
+required_columns = [
+    "Bacia_Codigo",
+    "Data_Ultima_Alteracao",
+    "Nome_Rio",
+    "Rio_Jurisdicao",
+    "Sub_Bacia_Codigo",
+    "codigorio",
+]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def rios_result(client):
+    """Fixture to fetch rios data once for all tests in this file."""
+    return await client.rios()
+
+
+@pytest.mark.asyncio
+async def test_estados_columns(rios_result):
+    """Test if rios result contains the required columns."""
+    assert all(col in rios_result.columns for col in required_columns), (
+        f"Missing columns in Estado result: {set(required_columns) - set(rios_result.columns)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_estados_not_empty(rios_result):
+    """Test if rios result is not empty."""
+    assert not rios_result.empty, "Estados result is empty"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def rios_codigo_filter(client):
+    """Fixture to fetch entidade by codigo."""
+    return await client.rios(codigo=codigo)
+
+
+@pytest.mark.asyncio
+async def test_rios_codigo_filter_not_empty(rios_codigo_filter):
+    """Test if filtering by codigo returns the correct entidade."""
+    assert not rios_codigo_filter.empty, f"No rios found for codigo {codigo}"
+
+
+@pytest.mark.asyncio
+async def test_rios_codigo_filter_correct(rios_codigo_filter):
+    assert rios_codigo_filter.iloc[0]["codigorio"] == codigo, (
+        f"Returned estado do not match codigo {codigo}"
+    )

--- a/tests/test_sub_bacias.py
+++ b/tests/test_sub_bacias.py
@@ -1,0 +1,50 @@
+import pytest_asyncio
+import pytest
+
+codigo = "10"
+required_columns = [
+    "Bacia_Codigo",
+    "Data_Ultima_Alteracao",
+    "Sub_Bacia_Nome",
+    "codigosubbacia",
+]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def sub_bacias_result(client):
+    """Fixture to fetch sub_bacias data once for all tests in this file."""
+    return await client.sub_bacias()
+
+
+@pytest.mark.asyncio
+async def test_sub_bacias_columns(sub_bacias_result):
+    """Test if sub_bacias result contains the required columns."""
+    assert all(col in sub_bacias_result.columns for col in required_columns), (
+        f"Missing columns in sub_bacias result: {set(required_columns) - set(sub_bacias_result.columns)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_bacias_not_empty(sub_bacias_result):
+    """Test if sub_bacias result is not empty."""
+    assert not sub_bacias_result.empty, "Bacias result is empty"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def sub_bacias_codigo_filter(client):
+    """Fixture to fetch bacia by codigo."""
+    return await client.sub_bacias(codigo=codigo)
+
+
+@pytest.mark.asyncio
+async def test_sub_bacia_codigo_filter_not_empty(sub_bacias_codigo_filter):
+    """Test if filtering by codigo returns the correct sub-bacia."""
+    assert not sub_bacias_codigo_filter.empty, f"No sub_bacia found for codigo {codigo}"
+
+
+@pytest.mark.asyncio
+async def test_sub_bacia_codigo_filter_correct(sub_bacias_codigo_filter):
+    codigo_returned = sub_bacias_codigo_filter.iloc[0]["codigosubbacia"]
+    assert codigo_returned == codigo, (
+        f"Returned sub_bacias do not match codigo {codigo}"
+    )


### PR DESCRIPTION
This pull request adds new asynchronous methods to the `Client` class for retrieving information about states, municipalities, sub-basins, and rivers from the API, each with optional filtering parameters. It also introduces comprehensive async test suites for each new method to ensure correct data retrieval and filtering.

### New API Methods in `Client`

* Added `estados`, `municipios`, `sub_bacias`, and `rios` async methods to `hidrowebsdk/client.py`, each allowing optional filtering by code and date range, and returning results as pandas DataFrames. [[1]](diffhunk://#diff-1e1c2e17f809b9755ab81b77526e9c810d0cc223f75139fe1d05ed8fe0a48489R266-R322) [[2]](diffhunk://#diff-1e1c2e17f809b9755ab81b77526e9c810d0cc223f75139fe1d05ed8fe0a48489R355-R418)

### Testing Enhancements

* Added `tests/test_estados.py` to verify that the `estados` method returns the required columns, is not empty, and supports filtering by code.
* Added `tests/test_municipios.py` to check that the `municipios` method returns the correct columns, is not empty, and can filter by code.
* Added `tests/test_sub_bacias.py` to ensure the `sub_bacias` method returns expected columns, non-empty results, and correct filtering.
* Added `tests/test_rios.py` for validating the `rios` method, including column presence, non-empty results, and code-based filtering.

### Example Usage Update

* Updated the example in the `_generic_func` to demonstrate usage of the new `sub_bacias` method.Add tests for estados, municipios, sub_bacias, and rios endpoints