### PR TITLE
Update version to 0.2.1, add rate limiting support, and enhance depen…

### DIFF
--- a/hidrowebsdk/__init__.py
+++ b/hidrowebsdk/__init__.py
@@ -4,7 +4,7 @@ HidroWebSDK - SDK Python para a API Hidroweb da ANA
 
 Este pacote fornece uma interface simples para se comunicar com a API Hidroweb da Agência Nacional de Águas (ANA) e acessar os dados hidrológicos disponíveis.
 
-.. versionadded:: 0.2.0
+.. versionadded:: 0.2.1
 
 Exemplo
 -------
@@ -17,7 +17,7 @@ Exemplo
 
 from .client import Client, RangeFilter, DateFilter
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "NVXtech"
 __email__ = "julio.werner@nvxtech.com.br"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hidrowebsdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK to communicate with ANA's HidroWeb API for hydrological and pluviometric data"
 authors = [
     {name = "Julio Werner", email = "julio.werner@nvxtech.com.br"}
@@ -25,6 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx",
+    "httpx-limiter>=0.4.0",
     "pandas",
 ]
 
@@ -41,3 +42,8 @@ Homepage = "https://nvxtech.github.io/hidrowebsdk/"
 Repository = "https://github.com/NVXtech/hidrowebsdk"
 Issues = "https://github.com/NVXtech/hidrowebsdk/issues"
 Documentation = "https://nvxtech.github.io/hidrowebsdk/"
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=1.2.0",
+]

--- a/tests/test_telemetric.py
+++ b/tests/test_telemetric.py
@@ -1,6 +1,8 @@
+from datetime import datetime, timedelta
+
 import pytest
 import pytest_asyncio
-from datetime import datetime, timedelta
+
 from hidrowebsdk import RangeFilter
 
 test_configs = [

--- a/uv.lock
+++ b/uv.lock
@@ -129,10 +129,11 @@ wheels = [
 
 [[package]]
 name = "hidrowebsdk"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "httpx-limiter" },
     { name = "pandas" },
 ]
 
@@ -144,9 +145,15 @@ dev = [
     { name = "sphinx-rtd-theme" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "httpx" },
+    { name = "httpx-limiter", specifier = ">=0.4.0" },
     { name = "pandas" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
@@ -154,6 +161,9 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-asyncio", specifier = ">=1.2.0" }]
 
 [[package]]
 name = "httpcore"
@@ -181,6 +191,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-limiter"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pyrate-limiter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/8d/77c18a5d147e0e8ddc6fe124d9e48ea43e52ba9f7c91a5ab49e4909550f5/httpx_limiter-0.4.0.tar.gz", hash = "sha256:b1c6a39f4bad7654fdd934da1e0119cd91e9bd2ad61b9adad623cd7081c1a3b7", size = 13603, upload-time = "2025-08-22T10:11:23.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/94/b2d08aaadd219313d4ec8c843a53643779815c2ef06e8982f79acc57f1d2/httpx_limiter-0.4.0-py3-none-any.whl", hash = "sha256:33d914c442bce14fc1d8f28e0a954c87d9f5f5a82b51a6778f1f1a3506d9e6ac", size = 15954, upload-time = "2025-08-22T10:11:22.348Z" },
 ]
 
 [[package]]
@@ -417,6 +440,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyrate-limiter"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/da/f682c5c5f9f0a5414363eb4397e6b07d84a02cde69c4ceadcbf32c85537c/pyrate_limiter-3.9.0.tar.gz", hash = "sha256:6b882e2c77cda07a241d3730975daea4258344b39c878f1dd8849df73f70b0ce", size = 289308, upload-time = "2025-07-30T14:36:58.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/af/d8bf0959ece9bc4679bd203908c31019556a421d76d8143b0c6871c7f614/pyrate_limiter-3.9.0-py3-none-any.whl", hash = "sha256:77357840c8cf97a36d67005d4e090787043f54000c12c2b414ff65657653e378", size = 33628, upload-time = "2025-07-30T14:36:57.71Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces several improvements and updates to the `hidrowebsdk` package, focusing on enhanced rate limiting, dependency management, and minor bug fixes. The most significant change is the addition of configurable rate limiting for API requests, which helps prevent hitting API usage limits. There are also updates to dependencies and minor corrections to the codebase and documentation.

**Rate limiting and client improvements:**

* Added support for configurable rate limiting in the `Client` class using `httpx-limiter`, allowing users to specify the maximum number of requests per second via the new `rate_limit` parameter. The default is set to 10 requests per second. (`hidrowebsdk/client.py`, `pyproject.toml`) [[1]](diffhunk://#diff-1e1c2e17f809b9755ab81b77526e9c810d0cc223f75139fe1d05ed8fe0a48489L18-R26) [[2]](diffhunk://#diff-1e1c2e17f809b9755ab81b77526e9c810d0cc223f75139fe1d05ed8fe0a48489L164-R166) [[3]](diffhunk://#diff-1e1c2e17f809b9755ab81b77526e9c810d0cc223f75139fe1d05ed8fe0a48489L176-R184) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R28)
* Updated the client initialization to use the new `AsyncRateLimitedTransport` for HTTP requests, improving API usage safety. (`hidrowebsdk/client.py`)

**Dependency and packaging updates:**

* Added `httpx-limiter` as a required dependency and introduced a `[dependency-groups]` section for development dependencies (e.g., `pytest-asyncio`). (`pyproject.toml`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R28) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R45-R49)
* Bumped the package version from `0.2.0` to `0.2.1` in both `pyproject.toml` and `__init__.py`. (`pyproject.toml`, `hidrowebsdk/__init__.py`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-93c3abd829de6496d6e147ca2f3b508e20900295d20864b11fd4f38c991d517aL7-R7) [[3]](diffhunk://#diff-93c3abd829de6496d6e147ca2f3b508e20900295d20864b11fd4f38c991d517aL20-R20)

**Bug fixes and code cleanup:**

* Corrected the values for multi-day `RangeFilter` enums (e.g., changed `"DIA_2"` to `"DIAS_2"`) to match the API specification. (`hidrowebsdk/client.py`)
* Removed a duplicate or outdated endpoint configuration for water quality series, preventing possible confusion or API errors. (`hidrowebsdk/client.py`)
* Minor import ordering and cleanup in test files. (`tests/test_telemetric.py`)